### PR TITLE
Read version information from ADDITIONAL_DEPENDENCIES in official-build.props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-snapshot": "./bin/install-snapshot.js",


### PR DESCRIPTION
This is required for quantum-ux, which will not match the UX Aspects release version.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3393