### PR TITLE
Update to support release of beta.x packages

### DIFF
--- a/bin/package-artifactory.js
+++ b/bin/package-artifactory.js
@@ -5,7 +5,7 @@ const { copySync, unlinkSync } = require('fs-extra');
 const glob = require('glob');
 const { basename, join } = require('path');
 const { argv, env, cwd } = require('process');
-const { getVersionWithoutPrerelease, setManifestVersion } = require('../lib/version');
+const { getVersionForRelease, setManifestVersion } = require('../lib/version');
 
 const args = argv.slice(2);
 
@@ -30,7 +30,7 @@ unlinkSync(package);
 if (env['RE_BUILD_TYPE'] === 'release') {
 
     // For a release candidate build, get the version without the prerelease suffix
-    const releaseVersion = getVersionWithoutPrerelease(env['VERSION']);
+    const releaseVersion = getVersionForRelease(env['VERSION']);
 
     // Update the manifest with the release version
     setManifestVersion(join(packageDir, 'package.json'), releaseVersion);

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,5 +1,5 @@
 const { readFile, readFileSync, writeFileSync } = require('fs');
-const { major, minor, patch } = require('semver');
+const { major, minor, patch, prerelease } = require('semver');
 const xml2js = require('xml2js');
 
 function getManifestVersion(path) {
@@ -42,6 +42,21 @@ async function getPomVersion(path) {
     return promise;
 }
 
+function getVersionForRelease(version) {
+
+    // Remove any trailing -SNAPSHOT
+    const v = version.replace('-SNAPSHOT', '');
+
+    // Check the prerelease for alpha or beta - these can be released.
+    const pre = prerelease(v);
+    if ((pre[0] === 'alpha' || pre[0] === 'beta') && pre.length > 1) {
+        return `${major(v)}.${minor(v)}.${patch(v)}-${pre[0]}.${pre[1]}`;
+    }
+
+    // Otherwise strip prerelease altogether
+    return getVersionWithoutPrerelease(v);
+}
+
 function getVersionWithoutPrerelease(version) {
     return `${major(version)}.${minor(version)}.${patch(version)}`;
 }
@@ -52,5 +67,6 @@ module.exports = {
     setVersion: setManifestVersion,
     setManifestVersion: setManifestVersion,
     getPomVersion: getPomVersion,
+    getVersionForRelease: getVersionForRelease,
     getVersionWithoutPrerelease: getVersionWithoutPrerelease
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-snapshot": "./bin/install-snapshot.js",


### PR DESCRIPTION
* Added `getVersionForRelease` with additional logic to preserve `alpha.x` and `beta.x` prereleases. This is used in the `package-artifactory` script.

https://portal.digitalsafe.net/browse/EL-3508