### PR TITLE
EL-3617 - Enable release of beta versions of UX Aspects

### DIFF
--- a/bin/package-artifactory.js
+++ b/bin/package-artifactory.js
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 
+/**
+ * Take an existing .tgz file and prepare it for publishing to Artifactory:
+ * 1. Move the existing package file to `target/artifactory`.
+ * 2. (If a release candidate build) Update the version number ready for release, re-package, and move it to
+ *    `target/release-staging`.
+ * Relevant environment variables:
+ * - `RE_BUILD_TYPE` - build type from SEPG.
+ * - `VERSION` - version from SEPG.
+ * - `VERSION_PRERELEASE` - optional, customize the prerelease affix.
+ */
+
 const { execSync } = require('child_process');
 const { copySync, unlinkSync } = require('fs-extra');
 const glob = require('glob');
@@ -29,8 +40,9 @@ unlinkSync(package);
 
 if (env['RE_BUILD_TYPE'] === 'release') {
 
-    // For a release candidate build, get the version without the prerelease suffix
-    const releaseVersion = getVersionForRelease(env['VERSION']);
+    // For a release candidate build, get the version without the prerelease suffix.
+    // A custom prerelease suffix specified by VERSION_PRERELEASE can replace it.
+    const releaseVersion = getVersionForRelease(env['VERSION'], env['VERSION_PRERELEASE']);
 
     // Update the manifest with the release version
     setManifestVersion(join(packageDir, 'package.json'), releaseVersion);

--- a/bin/setversion.js
+++ b/bin/setversion.js
@@ -2,12 +2,12 @@
 
 const { argv, env, exit } = require('process');
 const { existsSync } = require('fs-extra');
-const { getPomVersion, setManifestVersion } = require('../lib/version');
+const { getPomVersion, getVersionWithoutPrerelease, setManifestVersion } = require('../lib/version');
 
 (async () => {
 
     // extract the version from the environment variable or pom.xml
-    const version = env.VERSION || await getPomVersion('pom.xml');
+    const version = env.VERSION || getVersionWithoutPrerelease(await getPomVersion('pom.xml'));
 
     console.log(version);
 

--- a/bin/setversion.js
+++ b/bin/setversion.js
@@ -2,12 +2,23 @@
 
 const { argv, env, exit } = require('process');
 const { existsSync } = require('fs-extra');
-const { getPomVersion, getVersionWithoutPrerelease, setManifestVersion } = require('../lib/version');
+const { prerelease } = require('semver');
+const { getPomVersion, getVersionForRelease, getVersionWithoutPrerelease, setManifestVersion } = require('../lib/version');
 
 (async () => {
 
     // extract the version from the environment variable or pom.xml
-    const version = env.VERSION || getVersionWithoutPrerelease(await getPomVersion('pom.xml'));
+    let version;
+    if (env.VERSION) {
+        version = getVersionForRelease(env.VERSION, env.VERSION_PRERELEASE);
+        const buildPrerelease = prerelease(env.VERSION);
+        if (buildPrerelease) {
+            version += '-' + buildPrerelease.join('.');
+        }
+    } else {
+        // Used in dev environment only
+        version = getVersionWithoutPrerelease(await getPomVersion('pom.xml'));
+    }
 
     console.log(version);
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,5 +1,5 @@
 const { readFile, readFileSync, writeFileSync } = require('fs');
-const { major, minor, patch, prerelease } = require('semver');
+const { major, minor, patch } = require('semver');
 const xml2js = require('xml2js');
 
 function getManifestVersion(path) {
@@ -42,17 +42,20 @@ async function getPomVersion(path) {
     return promise;
 }
 
-function getVersionForRelease(version) {
+/**
+ * Get the NPM release version number from the SEPG version and optionally an explicit prerelease identifier.
+ * @param {string} version The SEPG version, in the form `1.2.3-4`.
+ * @param {string} prerelease The explicit prerelease to release with, e.g. `beta.1`.
+ */
+function getVersionForRelease(version, prerelease) {
 
-    // Check the prerelease for alpha or beta - these can be released.
-    const pre = prerelease(version);
-    if ((pre[0] === 'alpha' || pre[0] === 'beta') && pre.length > 1) {
-        const preNum = pre[1].replace(/\-.*/, '');
-        return `${major(version)}.${minor(version)}.${patch(version)}-${pre[0]}.${preNum}`;
+    const versionWithoutPrerelease = getVersionWithoutPrerelease(version);
+
+    if (prerelease) {
+        return `${versionWithoutPrerelease}-${prerelease}`;
     }
 
-    // Otherwise strip prerelease altogether
-    return getVersionWithoutPrerelease(version);
+    return versionWithoutPrerelease;
 }
 
 function getVersionWithoutPrerelease(version) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-snapshot": "./bin/install-snapshot.js",


### PR DESCRIPTION
The SEPG Auto Release job will not release a build containing a prerelease affix, e.g. `2.0.0-beta.3`. This proposed workaround will be to 1) set the main pom.xml version of each project to `2.0.0-SNAPSHOT` (remove the current prerelease specifier) and 2) specify the optional `VERSION_PRERELEASE` environment variable within the pom.xml file containing the required prerelease affix (e.g. `beta.3`).

This will allow the Jenkins job to process the build as a 2.0.0 release. In the build script, instead of taking the environment VERSION directly, we will combine this with the `VERSION_PRERELEASE` value when populating the version in package.json, causing the NPM package to contain the full version including prerelease.

The update to the setversion script also ensures that CI builds will include the prerelease component, after removing it from the pom.xml version.