### PR TITLE
Using --save-dev when installing snapshots

### DIFF
--- a/bin/install-snapshot.js
+++ b/bin/install-snapshot.js
@@ -23,14 +23,17 @@ if (!env['RE_BUILD_TYPE'] || env['RE_BUILD_TYPE'] === 'continuous') {
 
     setNpmConfig(tempConfig);
 
-    // Install snapshot packages
-    for (const package of packages) {
-        console.log(`Installing: ${package}`);
-        execSync(`npm install ${package}`, execOptions);
+    try {
+        // Install snapshot packages
+        for (const package of packages) {
+            console.log(`Installing: ${package}`);
+            execSync(`npm install --save-dev ${package}`, execOptions);
+        }
     }
-
-    // Revert temporary config
-    setNpmConfig(originalConfig)
+    finally {
+        // Revert temporary config
+        setNpmConfig(originalConfig);
+    }
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-snapshot": "./bin/install-snapshot.js",


### PR DESCRIPTION
* Installing a snapshot which is not currently listed in package.json causes it to be added by default to the dependencies. This is a problem for the quantum-ux-aspects package because there is currently no release of quantum-ux-white-label.
* Also fixed the issue of the .npmrc file not being reverted when an error occurs (e.g. package not found).