### PR TITLE
Install related dependencies

### DIFF
--- a/bin/install-ci.js
+++ b/bin/install-ci.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * Install one or more packages from the snapshot registry. This script will attempt to install packages related to the
+ * current build by assuming that any builds with dependent changes will have the same version number. (For SEPG feature
+ * builds, the version is derived from the git branch name.) If no related package is found then it will install either
+ * the version specified on the command line (if `package@version` format is provided), or the version specified in
+ * official-build.props (if `groupId:artifactId:npmPackageName` format is provided).
+ * Relevant environment variables:
+ * - `RE_BUILD_TYPE` - build type from SEPG.
+ * - `VERSION` - version from SEPG.
+ */
+
+const { argv, env } = require('process');
+const { getNpmPackages, install, useSnapshotRegistry } = require('../lib/install');
+
+const snapshotRegistry = 'https://svsartifactory.swinfra.net/artifactory/api/npm/saas-npm-dev-local';
+
+if (!env['RE_BUILD_TYPE'] || env['RE_BUILD_TYPE'] === 'continuous') {
+
+    const packages = getNpmPackages(argv.slice(2));
+
+    // Attempt to install packages using this build's version, falling back on the default snapshot if not present.
+    useSnapshotRegistry(snapshotRegistry, () => {
+        for (const package of packages) {
+
+            // Get package name with the same version as this build
+            const featurePackage = getPackageForCurrentFeature(package);
+
+            try {
+                // Attempt to install the feature package if it exists
+                install(featurePackage);
+            } catch (error) {
+                // Otherwise install the normal dependency
+                install(package);
+            }
+        }
+    })
+}
+
+/**
+ * Get a package name with the version replaced by the current build version.
+ * @param {string} package Package name, e.g. "@ux-aspects/ux-aspects@1.8.8".
+ */
+function getPackageForCurrentFeature(package) {
+    if (env['VERSION']) {
+        return package.substr(0, package.lastIndexOf('@') + 1) + env['VERSION'];
+    }
+
+    return package;
+}

--- a/bin/install-snapshot.js
+++ b/bin/install-snapshot.js
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
-const { execSync } = require('child_process');
-const { readFileSync, writeFileSync } = require('fs');
+/**
+ * Install one or more packages from the snapshot registry. It will install either the version specified on the command
+ * line (if `package@version` format is provided), or the version specified in official-build.props
+ * (if `groupId:artifactId:npmPackageName` format is provided).
+ * Relevant environment variables:
+ * - `RE_BUILD_TYPE` - build type from SEPG.
+ * - `VERSION` - version from SEPG.
+ */
+
 const { argv, env } = require('process');
-const { getVersionWithoutPrerelease } = require('../lib/version');
+const { getNpmPackages, install, useSnapshotRegistry } = require('../lib/install');
 
 const snapshotRegistry = 'https://svsartifactory.swinfra.net/artifactory/api/npm/saas-npm-dev-local';
 
@@ -11,103 +18,10 @@ if (!env['RE_BUILD_TYPE'] || env['RE_BUILD_TYPE'] === 'continuous') {
 
     const packages = getNpmPackages(argv.slice(2));
 
-    const execOptions = { stdio: [0, 1, 2] };
-
-    // Temporarily switch to use Artifactory for @ux-aspects and @micro-focus packages only
-    const originalConfig = getNpmConfig();
-    const tempConfig = {
-        ...originalConfig,
-        '@ux-aspects:registry': snapshotRegistry,
-        '@micro-focus:registry': snapshotRegistry
-    };
-
-    setNpmConfig(tempConfig);
-
-    try {
-        // Install snapshot packages
+    // Install packages using the snapshot registry
+    useSnapshotRegistry(snapshotRegistry, () => {
         for (const package of packages) {
-            console.log(`Installing: ${package}`);
-            execSync(`npm install --save-dev ${package}`, execOptions);
+            install(package);
         }
-    }
-    finally {
-        // Revert temporary config
-        setNpmConfig(originalConfig);
-    }
-}
-
-
-/**
- * Convert input args to an array of NPM package names with versions (`package@version`).
- * @param {string[]} args An array of either NPM package names, or the format `groupId:artifactId:npmPackageName`.
- */
-function getNpmPackages(args) {
-
-    // Get dependency info from official-build.props
-    const versions = getDependenciesWithVersions();
-
-    // Match args with version info from official-build.props
-    return args.map(arg => {
-        const pos = arg.lastIndexOf(':');
-        const name = arg.substr(0, pos);
-        const packageName = arg.substr(pos + 1);
-
-        // If the package name contains an NPM version specifier, just return that
-        if (packageName.indexOf('@', 1) > 0) {
-            return packageName;
-        }
-
-        // Use the version mapped from official-build.props if available; otherwise the environment version.
-        const version = versions[name] || `${getVersionWithoutPrerelease(env['VERSION'])}-SNAPSHOT`;
-        return `${packageName}@${version}`;
     });
-}
-
-/** Extract artifact names and versions from official-build.props as key/value pairs. */
-function getDependenciesWithVersions() {
-
-    let result = {};
-    try {
-        const text = readFileSync('official-build.props', 'utf8');
-        const matches = text.match(/^ADDITIONAL_DEPENDENCIES=(.+)$/m);
-        if (matches.length >= 2) {
-            const dependencies = matches[1].split(',');
-            result = dependencies.reduce((acc, val) => {
-                const pos = val.lastIndexOf(':');
-                acc[val.substr(0, pos)] = val.substr(pos + 1);
-                return acc;
-            }, {});
-        }
-    }
-    catch (error) {
-        console.warn(error);
-    }
-
-    return result;
-}
-
-/** Return .npmrc as a key/value object. */
-function getNpmConfig() {
-    const config = {};
-    try {
-        const text = readFileSync('.npmrc', 'utf8');
-        const lines = text.split('\n');
-        lines.forEach(line => {
-            const parts = line.split('=', 2);
-            if (parts.length === 2) {
-                config[parts[0]] = parts[1];
-            }
-        });
-    }
-    catch (error) {
-        console.warn(error);
-    }
-
-    return config;
-}
-
-/** Write a set of key/values to .npmrc. */
-function setNpmConfig(config) {
-    const text = Object.keys(config).reduce((str, key) => str + `${key}=${config[key]}\n`, '');
-    writeFileSync('.npmrc', text, { encoding: 'utf8' });
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,0 +1,122 @@
+const { execSync } = require('child_process');
+const { readFileSync, writeFileSync } = require('fs');
+const { env } = require('process');
+const { getVersionWithoutPrerelease } = require('../lib/version');
+
+const execOptions = { stdio: [0, 1, 2] };
+
+/**
+ * Install an NPM package.
+ * @param {string} package NPM package to install.
+ */
+function install(package) {
+    console.log(`Installing: ${package}`);
+    execSync(`npm install --save-dev ${package}`, execOptions);
+}
+
+/**
+ * Execute a callback with a temporary NPM registry configured in the project.
+ * @param {string} snapshotRegistry The URL of the temporary registry.
+ * @param {() => void} callback Callback to execute while the temporary registry is configured.
+ */
+function useSnapshotRegistry(snapshotRegistry, callback) {
+
+    // Temporarily switch to use Artifactory for @ux-aspects and @micro-focus packages only
+    const originalConfig = getNpmConfig();
+    const tempConfig = {
+        ...originalConfig,
+        '@ux-aspects:registry': snapshotRegistry,
+        '@micro-focus:registry': snapshotRegistry
+    };
+
+    setNpmConfig(tempConfig);
+
+    try {
+        callback();
+    }
+    finally {
+        // Revert temporary config
+        setNpmConfig(originalConfig);
+    }
+}
+
+/**
+ * Convert input args to an array of NPM package names with versions (`package@version`).
+ * @param {string[]} args An array of either NPM package names, or the format `groupId:artifactId:npmPackageName`.
+ */
+function getNpmPackages(args) {
+
+    // Get dependency info from official-build.props
+    const versions = getDependenciesWithVersions();
+
+    // Match args with version info from official-build.props
+    return args.map(arg => {
+        const pos = arg.lastIndexOf(':');
+        const name = arg.substr(0, pos);
+        const packageName = arg.substr(pos + 1);
+
+        // If the package name contains an NPM version specifier, just return that
+        if (packageName.indexOf('@', 1) > 0) {
+            return packageName;
+        }
+
+        // Use the version mapped from official-build.props if available; otherwise the environment version.
+        const version = versions[name] || `${getVersionWithoutPrerelease(env['VERSION'])}-SNAPSHOT`;
+        return `${packageName}@${version}`;
+    });
+}
+
+/** Extract artifact names and versions from official-build.props as key/value pairs. */
+function getDependenciesWithVersions() {
+
+    let result = {};
+    try {
+        const text = readFileSync('official-build.props', 'utf8');
+        const matches = text.match(/^ADDITIONAL_DEPENDENCIES=(.+)$/m);
+        if (matches.length >= 2) {
+            const dependencies = matches[1].split(',');
+            result = dependencies.reduce((acc, val) => {
+                const pos = val.lastIndexOf(':');
+                acc[val.substr(0, pos)] = val.substr(pos + 1);
+                return acc;
+            }, {});
+        }
+    }
+    catch (error) {
+        console.warn(error);
+    }
+
+    return result;
+}
+
+/** Return .npmrc as a key/value object. */
+function getNpmConfig() {
+    const config = {};
+    try {
+        const text = readFileSync('.npmrc', 'utf8');
+        const lines = text.split('\n');
+        lines.forEach(line => {
+            const parts = line.split('=', 2);
+            if (parts.length === 2) {
+                config[parts[0]] = parts[1];
+            }
+        });
+    }
+    catch (error) {
+        console.warn(error);
+    }
+
+    return config;
+}
+
+/** Write a set of key/values to .npmrc. */
+function setNpmConfig(config) {
+    const text = Object.keys(config).reduce((str, key) => str + `${key}=${config[key]}\n`, '');
+    writeFileSync('.npmrc', text, { encoding: 'utf8' });
+}
+
+module.exports = {
+    install: install,
+    useSnapshotRegistry: useSnapshotRegistry,
+    getNpmPackages: getNpmPackages
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
+    "ux-install-ci": "./bin/install-ci.js",
     "ux-install-snapshot": "./bin/install-snapshot.js",
     "ux-package-artifactory": "./bin/package-artifactory.js",
     "ux-setversion": "./bin/setversion.js",


### PR DESCRIPTION
Added a new `ux-install-ci` script which attempts to install dependencies with the same version as the build.

This means that, if you use the same branch name in each repo, you can have a CI build of ux-aspects-micro-focus incorporating changes in UXAspects and/or quantum-ux-aspects without having to merge first.