### PR TITLE
Fix for quantum-ux/quantum-ux-white-label

### DIFF
--- a/bin/install-ci.js
+++ b/bin/install-ci.js
@@ -15,6 +15,8 @@ const { argv, env } = require('process');
 const { getNpmPackages, install, useSnapshotRegistry } = require('../lib/install');
 
 const snapshotRegistry = 'https://svsartifactory.swinfra.net/artifactory/api/npm/saas-npm-dev-local';
+const versionRegex = /^\d+\.\d+\.\d+-(.+)-SNAPSHOT$/;
+const packageRegex = /^.+@\d+\.\d+\.\d+/;
 
 if (!env['RE_BUILD_TYPE'] || env['RE_BUILD_TYPE'] === 'continuous') {
 
@@ -39,12 +41,18 @@ if (!env['RE_BUILD_TYPE'] || env['RE_BUILD_TYPE'] === 'continuous') {
 }
 
 /**
- * Get a package name with the version replaced by the current build version.
- * @param {string} package Package name, e.g. "@ux-aspects/ux-aspects@1.8.8".
+ * Get a package name with the version affix replaced by the current build version affix.
+ * E.g. `@ux-aspects/ux-aspects@1.8.8-SNAPSHOT` => `@ux-aspects/ux-aspects@1.8.8-new-feature-SNAPSHOT`.
+ * @param {string} package Package name including version, e.g. `@ux-aspects/ux-aspects@1.8.8-SNAPSHOT`.
  */
 function getPackageForCurrentFeature(package) {
-    if (env['VERSION']) {
-        return package.substr(0, package.lastIndexOf('@') + 1) + env['VERSION'];
+
+    const versionMatch = versionRegex.exec(env['VERSION']);
+    if (versionMatch) {
+        const packageMatch = packageRegex.exec(package);
+        if (packageMatch) {
+            return `${packageMatch[0]}-${versionMatch[1]}-SNAPSHOT`;
+        }
     }
 
     return package;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-ci": "./bin/install-ci.js",


### PR DESCRIPTION
`quantum-ux-aspects` uses separate version numbers from `quantum-ux`, so instead of replacing the whole version we need to leave the version number intact.