### PR TITLE
Sanitize unsafe characters in the version; fix for beta builds

### DIFF
--- a/bin/setversion-release.js
+++ b/bin/setversion-release.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// Deprecated
+
 const { existsSync } = require('fs');
 const { cwd } = require('process');
 const { join } = require('path');

--- a/bin/setversion.js
+++ b/bin/setversion.js
@@ -2,22 +2,19 @@
 
 const { argv, env, exit } = require('process');
 const { existsSync } = require('fs-extra');
-const { prerelease } = require('semver');
-const { getPomVersion, getVersionForRelease, getVersionWithoutPrerelease, setManifestVersion } = require('../lib/version');
+const { getPomVersion, getVersionForCI, getVersionForRelease, setManifestVersion } = require('../lib/version');
 
 (async () => {
 
     // extract the version from the environment variable or pom.xml
     let version;
     if (env.VERSION) {
-        version = getVersionForRelease(env.VERSION, env.VERSION_PRERELEASE);
-        const buildPrerelease = prerelease(env.VERSION);
-        if (buildPrerelease) {
-            version += '-' + buildPrerelease.join('.');
-        }
+        // Get the version number with invalid characters removed.
+        // Not using the VERSION_PRERELEASE for CI builds in order to simplify installing dependencies.
+        version = getVersionForCI(env.VERSION);
     } else {
-        // Used in dev environment only
-        version = getVersionWithoutPrerelease(await getPomVersion('pom.xml'));
+        // Used in dev environment only to roll over the version after release
+        version = getVersionForRelease(await getPomVersion('pom.xml'));
     }
 
     console.log(version);

--- a/lib/version.js
+++ b/lib/version.js
@@ -43,13 +43,26 @@ async function getPomVersion(path) {
 }
 
 /**
+ * Get the NPM version number suitable for a CI release.
+ * @param {string} version The SEPG version.
+ */
+function getVersionForCI(version) {
+
+    // Strip out underscores
+    return getNormalizedVersion(version);
+}
+
+/**
  * Get the NPM release version number from the SEPG version and optionally an explicit prerelease identifier.
  * @param {string} version The SEPG version, in the form `1.2.3-4`.
  * @param {string} prerelease The explicit prerelease to release with, e.g. `beta.1`.
  */
 function getVersionForRelease(version, prerelease) {
 
-    const versionWithoutPrerelease = getVersionWithoutPrerelease(version);
+    // Strip out underscores
+    const normalizedVersion = getNormalizedVersion(version);
+
+    const versionWithoutPrerelease = getVersionWithoutPrerelease(normalizedVersion);
 
     if (prerelease) {
         return `${versionWithoutPrerelease}-${prerelease}`;
@@ -62,12 +75,21 @@ function getVersionWithoutPrerelease(version) {
     return `${major(version)}.${minor(version)}.${patch(version)}`;
 }
 
+/**
+ * Clean invalid characters from the given version identifier.
+ * @param {string} version The SEPG version.
+ */
+function getNormalizedVersion(version) {
+    return version.replace(/[^0-9A-Za-z\.\-\+]/g, '-');
+}
+
 module.exports = {
     getVersion: getManifestVersion,
     getManifestVersion: getManifestVersion,
     setVersion: setManifestVersion,
     setManifestVersion: setManifestVersion,
     getPomVersion: getPomVersion,
+    getVersionForCI: getVersionForCI,
     getVersionForRelease: getVersionForRelease,
     getVersionWithoutPrerelease: getVersionWithoutPrerelease
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-ci": "./bin/install-ci.js",


### PR DESCRIPTION
Added a normalization step to functions which return version identifiers potentially including a prerelease. This addresses the issue where SEPG injects an underscore into version prereleases.

Added `getVersionForCI` for use in setversion. This no longer applies the explicit prerelease (e.g. "beta.6") to the CI version. This was causing trouble when building related branches together, because the beta handling stuff is a workaround that SEPG doesn't know anything about. For now the CI builds will be `2.0.0-SNAPSHOT` instead of `2.0.0-beta.6-SNAPSHOT`, so I think it will be safe as long as we don't have to work on two prereleases of the same library at once.