### PR TITLE
Support install-ci in monorepos

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
-const { readFileSync, writeFileSync } = require('fs');
-const { env } = require('process');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+const { cwd, env } = require('process');
 const { getVersionWithoutPrerelease } = require('../lib/version');
 
 const execOptions = { stdio: [0, 1, 2] };
@@ -71,7 +72,7 @@ function getDependenciesWithVersions() {
 
     let result = {};
     try {
-        const text = readFileSync('official-build.props', 'utf8');
+        const text = readFileSync(findFile('official-build.props'), 'utf8');
         const matches = text.match(/^ADDITIONAL_DEPENDENCIES=(.+)$/m);
         if (matches.length >= 2) {
             const dependencies = matches[1].split(',');
@@ -87,6 +88,25 @@ function getDependenciesWithVersions() {
     }
 
     return result;
+}
+
+
+/**
+ * Check for the named file in the current dir, proceeding through the parent hierarchy until it is found.
+ * @param {string} name Name of the file.
+ * @returns {string} Full path to the located file.
+ */
+function findFile(name) {
+    let dir = cwd();
+    while (!existsSync(join(dir, name))) {
+        const prevDir = dir;
+        dir = join(dir, '..');
+        if (dir === prevDir) {
+            throw new Error(`Could not find '${name}' in ${cwd()} or its parents.`);
+        }
+    }
+
+    return join(dir, name);
 }
 
 /** Return .npmrc as a key/value object. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-scripts",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Build scripts for UX Aspects distributables.",
   "bin": {
     "ux-install-ci": "./bin/install-ci.js",


### PR DESCRIPTION
* Search up the filesystem hierarchy for official-build.props for dependency information. official-build.props must be in the root of the repository itself.

Made this change to support deploying our snapshots into https://github.houston.softwaregrp.net/caf/ux-aspects-deploy-test.